### PR TITLE
builder from console

### DIFF
--- a/examples/simple_server/build.sh
+++ b/examples/simple_server/build.sh
@@ -1,0 +1,4 @@
+mkdir -p build
+mkdir -p lib
+fpc simple_server.lpr @extra.cfg
+

--- a/examples/simple_server/extra.cfg
+++ b/examples/simple_server/extra.cfg
@@ -1,0 +1,11 @@
+#Language
+-FUlib/
+-O3 
+
+
+# Kyoukai Package
+-Fi../../src/inc/
+-Fu../../src/units/standard/
+-Fu../../src/units/other/
+
+-obuild/simple_server


### PR DESCRIPTION
with this tools, we can compile from console, without lazarus any more.

just build with
`$ ./build.sh
`

then will produce binary file at "build/simple_server", so you can run server with
`$ build/simple_server
`
we can implement it to other example projects


